### PR TITLE
OpenAI API functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'faraday'
+
 gem "rack-cors"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,12 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -160,6 +166,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.5)
       date
       net-protocol
@@ -391,6 +399,7 @@ DEPENDENCIES
   brakeman
   debug
   factory_bot_rails
+  faraday
   fuubar
   importmap-rails
   jbuilder

--- a/app/controllers/api/v1/recommendation_controller.rb
+++ b/app/controllers/api/v1/recommendation_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::RecommendationController < ApplicationController
+  require_relative '../../../gateways/openai_gateway'
 
   def index
     if params[:zip].blank?
@@ -8,12 +9,12 @@ class Api::V1::RecommendationController < ApplicationController
 
     processed_params = RecommendationParamsProcessor.new(params).process
 
-    if Rails.env.test? || Rails.env.development?
-      mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
-      api_response = JSON.parse(mock_response, symbolize_names: true)
-      render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
-      return
-    end
+    # if Rails.env.test? || Rails.env.development?
+    #   mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
+    #   api_response = JSON.parse(mock_response, symbolize_names: true)
+    #   render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
+    #   return
+    # end
 
     api_response = OpenAIGateway.new.generate_recommendations(processed_params)
 

--- a/app/controllers/api/v1/recommendation_controller.rb
+++ b/app/controllers/api/v1/recommendation_controller.rb
@@ -9,12 +9,12 @@ class Api::V1::RecommendationController < ApplicationController
 
     processed_params = RecommendationParamsProcessor.new(params).process
 
-    # if Rails.env.test? || Rails.env.development?
-    #   mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
-    #   api_response = JSON.parse(mock_response, symbolize_names: true)
-    #   render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
-    #   return
-    # end
+    if Rails.env.test? || Rails.env.development?
+      mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
+      api_response = JSON.parse(mock_response, symbolize_names: true)
+      render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
+      return
+    end
 
     api_response = OpenAIGateway.new.generate_recommendations(processed_params)
 

--- a/app/controllers/api/v1/recommendation_controller.rb
+++ b/app/controllers/api/v1/recommendation_controller.rb
@@ -18,10 +18,6 @@ class Api::V1::RecommendationController < ApplicationController
 
     api_response = OpenAIGateway.new.generate_recommendations(processed_params)
 
-    if api_response[:success]
-      render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
-    else
-      render json: { error: api_response[:error] }, status: 500
-    end
+    render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
   end
 end

--- a/app/controllers/api/v1/recommendation_controller.rb
+++ b/app/controllers/api/v1/recommendation_controller.rb
@@ -1,30 +1,23 @@
 class Api::V1::RecommendationController < ApplicationController
 
   def index
-    #call the openai gateway method to actually get data using params
-
-    stub_json = {
-      data: [
+    if Rails.env.test? || Rails.env.development?
+      # Checks if it is in testing or dev environments so it can mock response (will remove line 5 later)
+      mock_response_id = "mock-chatcmpl-123"
+      stub_json = [
         {
-          id: 1,
-          type: "plant",
-          attributes: {
-            name: 'strawberry',
-            short_description: 'red',
-            img_url: 'https://foodal.com/wp-content/uploads/2015/03/Make-Strawberry-Season-Last-All-Year.jpg'}
+          name: "Strawberry",
+          description: "Thrives in loamy soil and full sun, ideal for food production.",
+          image: "https://example.com/mock-strawberry.jpg"
         },
         {
-          id: 2,
-          type: "plant",
-          attributes: {
-            name: 'basil',
-            short_description: 'green',
-            img_url: 'https://the-growers.com/wp-content/uploads/2019/04/Basil-Leaves-Closeup.jpg'}
+          name: "Basil",
+          description: "Aromatic herb thriving in full sun with moderate watering.",
+          image: "https://example.com/mock-basil.jpg"
         }
       ]
-    }
-
-    render json: RecommendationSerializer.format_recommendations(stub_json[:data]), status: 200
+      render json: RecommendationSerializer.format_recommendations(stub_json, mock_response_id), status: 200
+      return
+    end
   end
-  
 end

--- a/app/controllers/api/v1/recommendation_controller.rb
+++ b/app/controllers/api/v1/recommendation_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::RecommendationController < ApplicationController
   require_relative '../../../gateways/openai_gateway'
 
   def index
-    if params[:zip].blank?
+    if params[:zip_code].blank?
       render json: { error: "Zip code is required." }, status: 400
       return
     end

--- a/app/gateways/openai_gateway.rb
+++ b/app/gateways/openai_gateway.rb
@@ -15,9 +15,9 @@ class OpenAIGateway
 
     if response.status == 200
       api_response = JSON.parse(response.body, symbolize_names: true)
-      raw_content = api_response[:choices][0][:message][:content]
-  
-      cleaned_content = raw_content.match(/\[.*\]/m)&.to_s
+      raw_content = api_response.dig(:choices, 0, :message, :content)
+    
+      cleaned_content = raw_content.match(/\[.*\]/m)&.to_s if raw_content
       if cleaned_content
         {
           success: true,
@@ -25,13 +25,13 @@ class OpenAIGateway
           data: JSON.parse(cleaned_content)
         }
       else
-        { success: false, error: "Unable to parse JSON from OpenAI response." }
+        { success: false, error: "Unexpected response format from OpenAI." }
       end
     else
       { success: false, error: "Failed to fetch plant recommendations." }
     end
-  rescue => error
-    { success: false, error: "An error occurred: #{error.message}" }
+    rescue => error
+      { success: false, error: "An error occurred: #{error.message}" }
   end
 
   private

--- a/app/gateways/openai_gateway.rb
+++ b/app/gateways/openai_gateway.rb
@@ -1,5 +1,47 @@
 class OpenAIGateway
-  
+  def generate_recommendations(params)
+    prompt = build_prompt(params)
 
-  
+    response = Faraday.post("https://api.openai.com/v1/chat/completions") do |req|
+      req.headers['Content-Type'] = 'application/json'
+      req.headers['Authorization'] = "Bearer #{ENV['OPENAI_API_KEY']}"
+      req.body = {
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: prompt }],
+        max_tokens: 300,
+        temperature: 0.7
+      }.to_json
+    end
+
+    if response.status == 200
+      api_response = JSON.parse(response.body, symbolize_names: true)
+      {
+        success: true,
+        id: api_response[:id],
+        data: JSON.parse(api_response[:choices][0][:message][:content])
+      }
+    else
+      { success: false, error: "Failed to fetch plant recommendations." }
+    end
+  rescue => error
+    { success: false, error: "An error occurred: #{error.message}" }
+  end
+
+  private
+
+  def build_prompt(params)
+    "
+      Suggest 2-3 plants for a garden based on these criteria:
+      Zip: #{params[:zip]}, Sunlight: #{params[:sunlight]}, Soil: #{params[:soil_type]},
+      Water: #{params[:water_needs]}, Purpose: #{params[:purpose]}.
+      Return JSON with the following structure:
+      [
+        {
+          \"name\": \"Plant Name\",
+          \"description\": \"Brief sentence about why this plant is suitable.\",
+          \"image\": \"URL to a real example image of the plant\"
+        }
+      ]
+    "
+  end
 end

--- a/app/gateways/openai_gateway.rb
+++ b/app/gateways/openai_gateway.rb
@@ -1,0 +1,5 @@
+class OpenAIGateway
+  
+
+  
+end

--- a/app/gateways/openai_gateway.rb
+++ b/app/gateways/openai_gateway.rb
@@ -39,7 +39,7 @@ class OpenAIGateway
   def build_prompt(params)
     "
       Suggest 2-3 plants for a garden based on these criteria:
-      Zip: #{params[:zip]}, Sunlight: #{params[:sunlight]}, Soil: #{params[:soil_type]},
+      Zip: #{params[:zip_code]}, Sunlight: #{params[:sunlight]}, Soil: #{params[:soil_type]},
       Water: #{params[:water_needs]}, Purpose: #{params[:purpose]}.
       ONLY return a JSON array where each element has the following keys:
       - name: the plant's name

--- a/app/gateways/openai_gateway.rb
+++ b/app/gateways/openai_gateway.rb
@@ -9,7 +9,7 @@ class OpenAIGateway
         model: "gpt-4o-mini",
         messages: [{ role: "user", content: prompt }],
         max_tokens: 300,
-        temperature: 0.5
+        temperature: 0.7
       }.to_json
     end
 

--- a/app/poros/recommendation_params_processor.rb
+++ b/app/poros/recommendation_params_processor.rb
@@ -1,0 +1,27 @@
+class RecommendationParamsProcessor
+  DEFAULTS = {
+    sunlight: "Full Sun",
+    soil_type: "Loamy",
+    water_needs: "Moderate"
+  }.freeze
+
+  def initialize(params)
+    @params = params
+  end
+
+  def process
+    {
+      zip: @params[:zip],
+      sunlight: process_field(:sunlight),
+      soil_type: process_field(:soil_type),
+      water_needs: process_field(:water_needs),
+      purpose: @params[:purpose]
+    }
+  end
+
+  private
+
+  def process_field(field)
+    @params[field] == "Don't Know" ? DEFAULTS[field] : @params[field]
+  end
+end

--- a/app/poros/recommendation_params_processor.rb
+++ b/app/poros/recommendation_params_processor.rb
@@ -11,7 +11,7 @@ class RecommendationParamsProcessor
 
   def process
     {
-      zip: @params[:zip],
+      zip_code: @params[:zip_code],
       sunlight: process_field(:sunlight),
       soil_type: process_field(:soil_type),
       water_needs: process_field(:water_needs),

--- a/app/serializers/recommendation_serializer.rb
+++ b/app/serializers/recommendation_serializer.rb
@@ -7,9 +7,9 @@ class RecommendationSerializer
           index: index,
           type: "plant",
           attributes: {
-            name: recommendation[:name],
-            description: recommendation[:description],
-            image: recommendation[:image]
+            name: recommendation[:name] || recommendation["name"],
+            description: recommendation[:description] || recommendation["description"],
+            image: recommendation[:image] || recommendation["image"]
           }
         }
       end

--- a/app/serializers/recommendation_serializer.rb
+++ b/app/serializers/recommendation_serializer.rb
@@ -1,20 +1,18 @@
 class RecommendationSerializer
-
-
-  def self.format_recommendations(recommendations)
+  def self.format_recommendations(recommendations, response_id)
     {
-    data: 
-    recommendations.map do |recommendation|
-      {
-        id: recommendation[:id],
-        type: "plant",
-        attributes: {
-          name: recommendation[:attributes][:name],
-          short_description: recommendation[:attributes][:short_description],
-          img_url: recommendation[:attributes][:img_url]
+      id: response_id,
+      data: recommendations.map.with_index(1) do |recommendation, index|
+        {
+          index: index,
+          type: "plant",
+          attributes: {
+            name: recommendation[:name],
+            description: recommendation[:description],
+            image: recommendation[:image]
+          }
         }
-      }
-    end
-  }
+      end
+    }
   end
 end

--- a/spec/fixtures/openai_gateway_stubbed.json
+++ b/spec/fixtures/openai_gateway_stubbed.json
@@ -1,0 +1,10 @@
+{
+  "id": "mock-chatcmpl-123",
+  "choices": [
+    {
+      "message": {
+        "content": "[{\"name\":\"Tomato\",\"description\":\"Thrives in full sun.\",\"image\":\"https://example.com/tomato.jpg\"},{\"name\":\"Basil\",\"description\":\"Loves moderate water and sun.\",\"image\":\"https://example.com/basil.jpg\"}]"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/recommendation_stubbed_response.json
+++ b/spec/fixtures/recommendation_stubbed_response.json
@@ -1,0 +1,21 @@
+{
+  "id": "mock-chatcmpl-123",
+  "choices": [
+    {
+      "message": {
+        "content": [
+          {
+            "name": "Strawberry",
+            "description": "Thrives in loamy soil and full sun, ideal for food production.",
+            "image": "https://example.com/mock-strawberry.jpg"
+          },
+          {
+            "name": "Basil",
+            "description": "Aromatic herb thriving in full sun with moderate watering.",
+            "image": "https://example.com/mock-basil.jpg"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/fixtures/recommendation_stubbed_response.json
+++ b/spec/fixtures/recommendation_stubbed_response.json
@@ -1,21 +1,15 @@
 {
   "id": "mock-chatcmpl-123",
-  "choices": [
+  "data": [
     {
-      "message": {
-        "content": [
-          {
-            "name": "Strawberry",
-            "description": "Thrives in loamy soil and full sun, ideal for food production.",
-            "image": "https://example.com/mock-strawberry.jpg"
-          },
-          {
-            "name": "Basil",
-            "description": "Aromatic herb thriving in full sun with moderate watering.",
-            "image": "https://example.com/mock-basil.jpg"
-          }
-        ]
-      }
+      "name": "Strawberry",
+      "description": "Thrives in loamy soil and full sun, ideal for food production.",
+      "image": "https://example.com/mock-strawberry.jpg"
+    },
+    {
+      "name": "Basil",
+      "description": "Aromatic herb thriving in full sun with moderate watering.",
+      "image": "https://example.com/mock-basil.jpg"
     }
   ]
 }

--- a/spec/gateways/openai_gateway_spec.rb
+++ b/spec/gateways/openai_gateway_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+require_relative '../../app/gateways/openai_gateway'
+
+RSpec.describe OpenAIGateway do
+  describe "generate_recommendations" do
+    let(:valid_params) do
+      {
+        zip: "80221",
+        sunlight: "Full Sun",
+        soil_type: "Loamy",
+        water_needs: "Moderate",
+        purpose: "Food Production"
+      }
+    end
+
+    it "returns recommendations when OpenAI API responds successfully" do
+      stubbed_response = File.read("spec/fixtures/openai_gateway_stubbed.json")
+
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .with(
+          headers: {
+            "Content-Type" => "application/json",
+            "Authorization" => "Bearer #{Rails.application.credentials.dig(:open_ai, :key)}"
+          }
+        )
+        .to_return(status: 200, body: stubbed_response)
+
+      gateway = OpenAIGateway.new
+      result = gateway.generate_recommendations(valid_params)
+
+      expect(result[:success]).to be true
+      expect(result[:id]).to eq("mock-chatcmpl-123")
+      expect(result[:data]).to be_an Array
+      expect(result[:data].length).to eq(2)
+
+      first_recommendation = result[:data][0]
+      expect(first_recommendation["name"]).to eq("Tomato")
+      expect(first_recommendation["description"]).to eq("Thrives in full sun.")
+      expect(first_recommendation["image"]).to eq("https://example.com/tomato.jpg")
+    end
+
+    it "handles API errors gracefully" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_return(status: 500, body: "")
+
+      gateway = OpenAIGateway.new
+      result = gateway.generate_recommendations(valid_params)
+
+      expect(result[:success]).to be false
+      expect(result[:error]).to eq("Failed to fetch plant recommendations.")
+    end
+
+    it "handles unexpected response format" do
+      stubbed_response = { id: "mock-chatcmpl-123", choices: [] }.to_json
+
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_return(status: 200, body: stubbed_response)
+
+      gateway = OpenAIGateway.new
+      result = gateway.generate_recommendations(valid_params)
+
+      expect(result[:success]).to be false
+      expect(result[:error]).to eq("Unexpected response format from OpenAI.")
+    end
+
+    it "handles exceptions gracefully" do
+      allow(Faraday).to receive(:post).and_raise(StandardError.new("Connection error"))
+
+      gateway = OpenAIGateway.new
+      result = gateway.generate_recommendations(valid_params)
+
+      expect(result[:success]).to be false
+      expect(result[:error]).to eq("An error occurred: Connection error")
+    end
+  end
+end

--- a/spec/gateways/openai_gateway_spec.rb
+++ b/spec/gateways/openai_gateway_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OpenAIGateway do
   describe "generate_recommendations" do
     let(:valid_params) do
       {
-        zip: "80221",
+        zip_code: "80221",
         sunlight: "Full Sun",
         soil_type: "Loamy",
         water_needs: "Moderate",

--- a/spec/poros/recommentation_params_processor_spec.rb
+++ b/spec/poros/recommentation_params_processor_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe RecommendationParamsProcessor do
+  describe '#process' do
+    let(:valid_params) do
+      {
+        zip: "80221",
+        sunlight: "Partial Shade",
+        soil_type: "Clay",
+        water_needs: "High",
+        purpose: "Food Production"
+      }
+    end
+
+    let(:params_with_defaults) do
+      {
+        zip: "80221",
+        sunlight: "Don't Know",
+        soil_type: "Don't Know",
+        water_needs: "Don't Know",
+        purpose: "Food Production"
+      }
+    end
+
+    it 'returns processed parameters with valid input' do
+      processor = RecommendationParamsProcessor.new(valid_params)
+      result = processor.process
+
+      expect(result[:zip]).to eq("80221")
+      expect(result[:sunlight]).to eq("Partial Shade")
+      expect(result[:soil_type]).to eq("Clay")
+      expect(result[:water_needs]).to eq("High")
+      expect(result[:purpose]).to eq("Food Production")
+    end
+
+    it 'uses defaults for "Do not Know" values' do
+      processor = RecommendationParamsProcessor.new(params_with_defaults)
+      result = processor.process
+
+      expect(result[:zip]).to eq("80221")
+      expect(result[:sunlight]).to eq("Full Sun")
+      expect(result[:soil_type]).to eq("Loamy")
+      expect(result[:water_needs]).to eq("Moderate")
+      expect(result[:purpose]).to eq("Food Production")
+    end
+  end
+end

--- a/spec/poros/recommentation_params_processor_spec.rb
+++ b/spec/poros/recommentation_params_processor_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RecommendationParamsProcessor do
   describe '#process' do
     let(:valid_params) do
       {
-        zip: "80221",
+        zip_code: "80221",
         sunlight: "Partial Shade",
         soil_type: "Clay",
         water_needs: "High",
@@ -14,7 +14,7 @@ RSpec.describe RecommendationParamsProcessor do
 
     let(:params_with_defaults) do
       {
-        zip: "80221",
+        zip_code: "80221",
         sunlight: "Don't Know",
         soil_type: "Don't Know",
         water_needs: "Don't Know",
@@ -26,7 +26,7 @@ RSpec.describe RecommendationParamsProcessor do
       processor = RecommendationParamsProcessor.new(valid_params)
       result = processor.process
 
-      expect(result[:zip]).to eq("80221")
+      expect(result[:zip_code]).to eq("80221")
       expect(result[:sunlight]).to eq("Partial Shade")
       expect(result[:soil_type]).to eq("Clay")
       expect(result[:water_needs]).to eq("High")
@@ -37,7 +37,7 @@ RSpec.describe RecommendationParamsProcessor do
       processor = RecommendationParamsProcessor.new(params_with_defaults)
       result = processor.process
 
-      expect(result[:zip]).to eq("80221")
+      expect(result[:zip_code]).to eq("80221")
       expect(result[:sunlight]).to eq("Full Sun")
       expect(result[:soil_type]).to eq("Loamy")
       expect(result[:water_needs]).to eq("Moderate")

--- a/spec/requests/api/v1/recommendation_request_spec.rb
+++ b/spec/requests/api/v1/recommendation_request_spec.rb
@@ -31,5 +31,23 @@ RSpec.describe 'Recommendation API', type: :request do
               headers: { 'Content-Type' => 'application/json' }
             )
     end
+
+    it 'returns recommendations based on valid parameters' do
+      get "/api/v1/recommendation", 
+          params: { 
+            zip: 80221, 
+            sunlight: "full_sun", 
+            soil_type: "clay", 
+            water_needs: "low_water", 
+            purpose: "edible" 
+          }, 
+          as: :json
+      
+      expect(response).to be_successful
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      binding.pry
+    end
   end
 end

--- a/spec/requests/api/v1/recommendation_request_spec.rb
+++ b/spec/requests/api/v1/recommendation_request_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'Recommendation API', type: :request do
             purpose: "edible" 
           }, 
           as: :json
+
+      Rails.logger.info("Response Body: #{response.body}")
       
       expect(response).to be_successful
 

--- a/spec/requests/api/v1/recommendation_request_spec.rb
+++ b/spec/requests/api/v1/recommendation_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Recommendation API', type: :request do
       it 'returns recommendations based on valid parameters' do
         get "/api/v1/recommendation", 
             params: { 
-              zip: 80221, 
+              zip_code: 80221, 
               sunlight: "full_sun", 
               soil_type: "clay", 
               water_needs: "low_water", 

--- a/spec/requests/api/v1/recommendation_request_spec.rb
+++ b/spec/requests/api/v1/recommendation_request_spec.rb
@@ -47,7 +47,19 @@ RSpec.describe 'Recommendation API', type: :request do
 
       json = JSON.parse(response.body, symbolize_names: true)
 
-      binding.pry
+      expect(json[:id]).to eq("mock-chatcmpl-123")
+
+      expect(json[:data].length).to eq(2)
+
+      expect(json[:data][0][:index]).to eq(1)
+      expect(json[:data][0][:attributes][:name]).to eq("Strawberry")
+      expect(json[:data][0][:attributes][:description]).to eq("Thrives in loamy soil and full sun, ideal for food production.")
+      expect(json[:data][0][:attributes][:image]).to eq("https://example.com/mock-strawberry.jpg")
+
+      expect(json[:data][1][:index]).to eq(2)
+      expect(json[:data][1][:attributes][:name]).to eq("Basil")
+      expect(json[:data][1][:attributes][:description]).to eq("Aromatic herb thriving in full sun with moderate watering.")
+      expect(json[:data][1][:attributes][:image]).to eq("https://example.com/mock-basil.jpg")
     end
   end
 end

--- a/spec/requests/api/v1/recommendation_request_spec.rb
+++ b/spec/requests/api/v1/recommendation_request_spec.rb
@@ -2,41 +2,56 @@ require 'rails_helper'
 
 RSpec.describe 'Recommendation API', type: :request do
   describe 'get recommendations' do
-    before do
-      WebMock.stub_request(:post, "https://api.openai.com/v1/chat/completions")
-            .to_return(status: 200, body: File.read("spec/fixtures/recommendation_stubbed_response.json"))
+    context 'happy path' do
+      before do
+        WebMock.stub_request(:get, "https://api.openai.com/v1/chat/completions")
+              .to_return(status: 200, body: File.read("spec/fixtures/recommendation_stubbed_response.json"))
+      end
+
+      it 'returns recommendations based on valid parameters' do
+        get "/api/v1/recommendation", 
+            params: { 
+              zip: 80221, 
+              sunlight: "full_sun", 
+              soil_type: "clay", 
+              water_needs: "low_water", 
+              purpose: "edible" 
+            }, 
+            as: :json
+
+        Rails.logger.info("Response Body: #{response.body}")
+        
+        expect(response).to be_successful
+
+        json = JSON.parse(response.body, symbolize_names: true)
+
+        expect(json[:id]).to eq("mock-chatcmpl-123")
+
+        expect(json[:data].length).to eq(2)
+
+        expect(json[:data][0][:index]).to eq(1)
+        expect(json[:data][0][:attributes][:name]).to eq("Strawberry")
+        expect(json[:data][0][:attributes][:description]).to eq("Thrives in loamy soil and full sun, ideal for food production.")
+        expect(json[:data][0][:attributes][:image]).to eq("https://example.com/mock-strawberry.jpg")
+
+        expect(json[:data][1][:index]).to eq(2)
+        expect(json[:data][1][:attributes][:name]).to eq("Basil")
+        expect(json[:data][1][:attributes][:description]).to eq("Aromatic herb thriving in full sun with moderate watering.")
+        expect(json[:data][1][:attributes][:image]).to eq("https://example.com/mock-basil.jpg")
+      end
     end
 
-    it 'returns recommendations based on valid parameters' do
-      get "/api/v1/recommendation", 
-          params: { 
-            zip: 80221, 
-            sunlight: "full_sun", 
-            soil_type: "clay", 
-            water_needs: "low_water", 
-            purpose: "edible" 
-          }, 
-          as: :json
+    context 'sad path' do
+      it 'returns a 400 error if zip code is missing' do
+        get "/api/v1/recommendation", 
+            params: { sunlight: "full_sun", soil_type: "clay", water_needs: "low_water", purpose: "edible" }, 
+            as: :json
 
-      Rails.logger.info("Response Body: #{response.body}")
-      
-      expect(response).to be_successful
+        expect(response).to have_http_status(400)
 
-      json = JSON.parse(response.body, symbolize_names: true)
-
-      expect(json[:id]).to eq("mock-chatcmpl-123")
-
-      expect(json[:data].length).to eq(2)
-
-      expect(json[:data][0][:index]).to eq(1)
-      expect(json[:data][0][:attributes][:name]).to eq("Strawberry")
-      expect(json[:data][0][:attributes][:description]).to eq("Thrives in loamy soil and full sun, ideal for food production.")
-      expect(json[:data][0][:attributes][:image]).to eq("https://example.com/mock-strawberry.jpg")
-
-      expect(json[:data][1][:index]).to eq(2)
-      expect(json[:data][1][:attributes][:name]).to eq("Basil")
-      expect(json[:data][1][:attributes][:description]).to eq("Aromatic herb thriving in full sun with moderate watering.")
-      expect(json[:data][1][:attributes][:image]).to eq("https://example.com/mock-basil.jpg")
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(json[:error]).to eq("Zip code is required.")
+      end
     end
   end
 end

--- a/spec/requests/api/v1/recommendation_request_spec.rb
+++ b/spec/requests/api/v1/recommendation_request_spec.rb
@@ -2,18 +2,34 @@ require 'rails_helper'
 
 RSpec.describe 'Recommendation API', type: :request do
   describe 'get recommendations' do
-    it 'can get a recommendation based on a valid request' do
-      get "/api/v1/recommendation", params: {zip: 80221, sunlight: "full_sun", soil_type: "clay", water_needs: "low_water", purpose: "edible"}, as: :json
-
-      expect(response).to be_successful
-      json = JSON.parse(response.body, symbolize_names: true)
-      
-      expect(json[:data].length).to eq(2)
-      expect(json[:data][0][:id]).to eq(1)
-      expect(json[:data][0][:type]).to eq("plant")
-      expect(json[:data][0][:attributes][:name]).to eq("strawberry")
-      expect(json[:data][0][:attributes][:short_description]).to eq("red")
-      expect(json[:data][0][:attributes][:img_url]).to eq("https://foodal.com/wp-content/uploads/2015/03/Make-Strawberry-Season-Last-All-Year.jpg")
+    before do
+      WebMock.stub_request(:post, "https://api.openai.com/v1/chat/completions")
+            .to_return(
+              status: 200,
+              body: {
+                id: "mock-chatcmpl-123",
+                object: "chat.completion",
+                choices: [
+                  {
+                    message: {
+                      content: [
+                        {
+                          name: "Strawberry",
+                          description: "Thrives in loamy soil and full sun, ideal for food production.",
+                          image: "https://example.com/mock-strawberry.jpg"
+                        },
+                        {
+                          name: "Basil",
+                          description: "Aromatic herb thriving in full sun with moderate watering.",
+                          image: "https://example.com/mock-basil.jpg"
+                        }
+                      ].to_json
+                    }
+                  }
+                ]
+              }.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
     end
   end
 end

--- a/spec/requests/api/v1/recommendation_request_spec.rb
+++ b/spec/requests/api/v1/recommendation_request_spec.rb
@@ -4,32 +4,7 @@ RSpec.describe 'Recommendation API', type: :request do
   describe 'get recommendations' do
     before do
       WebMock.stub_request(:post, "https://api.openai.com/v1/chat/completions")
-            .to_return(
-              status: 200,
-              body: {
-                id: "mock-chatcmpl-123",
-                object: "chat.completion",
-                choices: [
-                  {
-                    message: {
-                      content: [
-                        {
-                          name: "Strawberry",
-                          description: "Thrives in loamy soil and full sun, ideal for food production.",
-                          image: "https://example.com/mock-strawberry.jpg"
-                        },
-                        {
-                          name: "Basil",
-                          description: "Aromatic herb thriving in full sun with moderate watering.",
-                          image: "https://example.com/mock-basil.jpg"
-                        }
-                      ].to_json
-                    }
-                  }
-                ]
-              }.to_json,
-              headers: { 'Content-Type' => 'application/json' }
-            )
+            .to_return(status: 200, body: File.read("spec/fixtures/recommendation_stubbed_response.json"))
     end
 
     it 'returns recommendations based on valid parameters' do


### PR DESCRIPTION
Adds ability to call OpenAI API to get back 2-3 plants returned in JSON.

Made gateway and poro for controller with test suites for them.

In recommendation_request_spec lines 19 and 21 are not covered as of right now.

Poro and Gateway are 100% covered, when running requests it shows the gateway is poorly covered but technically it is.

The master.key was sent via private message in slack, please change your master.key to the one I provided. 

There is a new gem Faraday so don't forget to do a bundle install.

In recommendation_controller lines 12-17 are conditional for test and development environment. If running a request in Postman, it will hit mock data. To make a real OpenAI API call, those lines need to be commented out before sending the call through Postman.

The actual AI prompt that is sent to OpenAI might need to be tweaked for the images. I have encountered inconsistent image URL returns where some work but some are not valid. We will iron this out in the next few days.