### PR TITLE
Google API Integration

### DIFF
--- a/app/controllers/api/v1/recommendation_controller.rb
+++ b/app/controllers/api/v1/recommendation_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::RecommendationController < ApplicationController
   require_relative '../../../gateways/openai_gateway'
+  require_relative '../../../gateways/google_search_gateway'
 
   def index
     if params[:zip_code].blank?
@@ -9,15 +10,21 @@ class Api::V1::RecommendationController < ApplicationController
 
     processed_params = RecommendationParamsProcessor.new(params).process
 
-    if Rails.env.test? || Rails.env.development?
-      mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
-      api_response = JSON.parse(mock_response, symbolize_names: true)
-      render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
-      return
-    end
+    # if Rails.env.test? || Rails.env.development?
+    #   mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
+    #   api_response = JSON.parse(mock_response, symbolize_names: true)
+    #   enriched_data = GoogleSearchGateway.new.enrich_with_google_data(api_response[:data])
+    #   render json: RecommendationSerializer.format_recommendations(enriched_data, api_response[:id]), status: 200
+    #   return
+    # end
 
     api_response = OpenaiGateway.new.generate_recommendations(processed_params)
 
-    render json: RecommendationSerializer.format_recommendations(api_response[:data], api_response[:id]), status: 200
+    if api_response[:success]
+      enriched_data = GoogleSearchGateway.new.enrich_with_google_data(api_response[:data])
+      render json: RecommendationSerializer.format_recommendations(enriched_data, api_response[:id]), status: 200
+    else
+      render json: ErrorSerializer.format_errors(api_response[:error]), status: :internal_server_error
+    end
   end
 end

--- a/app/controllers/api/v1/recommendation_controller.rb
+++ b/app/controllers/api/v1/recommendation_controller.rb
@@ -10,13 +10,13 @@ class Api::V1::RecommendationController < ApplicationController
 
     processed_params = RecommendationParamsProcessor.new(params).process
 
-    # if Rails.env.test? || Rails.env.development?
-    #   mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
-    #   api_response = JSON.parse(mock_response, symbolize_names: true)
-    #   enriched_data = GoogleSearchGateway.new.enrich_with_google_data(api_response[:data])
-    #   render json: RecommendationSerializer.format_recommendations(enriched_data, api_response[:id]), status: 200
-    #   return
-    # end
+    if Rails.env.test? || Rails.env.development?
+      mock_response = File.read("spec/fixtures/recommendation_stubbed_response.json")
+      api_response = JSON.parse(mock_response, symbolize_names: true)
+      enriched_data = GoogleSearchGateway.new.enrich_with_google_data(api_response[:data])
+      render json: RecommendationSerializer.format_recommendations(enriched_data, api_response[:id]), status: 200
+      return
+    end
 
     api_response = OpenaiGateway.new.generate_recommendations(processed_params)
 

--- a/app/gateways/google_search_gateway.rb
+++ b/app/gateways/google_search_gateway.rb
@@ -15,7 +15,7 @@ class GoogleSearchGateway
     plant_data.map do |plant|
       if plant[:name].present? || plant["name"].present?
         google_data = fetch_google_data(plant[:name] || plant["name"])
-        plant.merge(google_data) if google_data
+        google_data ? plant.merge(google_data) : plant
       else
         plant
       end

--- a/app/gateways/google_search_gateway.rb
+++ b/app/gateways/google_search_gateway.rb
@@ -1,0 +1,58 @@
+class GoogleSearchGateway
+  BASE_URL = "https://www.googleapis.com/customsearch/v1"
+  DEFAULT_SEARCH_TYPE = "image"
+  DEFAULT_RESULTS_COUNT = 1
+
+  def initialize(
+    api_key: Rails.application.credentials.dig(:google_api, :key),
+    search_engine_id: Rails.application.credentials.dig(:google_api, :search_engine_id)
+  )
+    @api_key = api_key
+    @search_engine_id = search_engine_id
+  end
+
+  def enrich_with_google_data(plant_data)
+    plant_data.map do |plant|
+      if plant[:name].present? || plant["name"].present?
+        google_data = fetch_google_data(plant[:name] || plant["name"])
+        plant.merge(google_data) if google_data
+      else
+        plant
+      end
+    end
+  end
+  
+  private
+
+  def fetch_google_data(query)
+    response = Faraday.get(BASE_URL, request_params(query))
+    handle_response(response)
+  rescue StandardError => error
+    nil
+  end
+
+  def request_params(query)
+    {
+      key: @api_key,
+      cx: @search_engine_id,
+      q: query,
+      searchType: DEFAULT_SEARCH_TYPE,
+      num: DEFAULT_RESULTS_COUNT
+    }
+  end
+
+  def handle_response(response)
+    return unless response.status == 200
+
+    results = JSON.parse(response.body, symbolize_names: true)
+    first_result = results.dig(:items, 0)
+    return unless first_result
+
+    {
+      image: first_result[:link],
+      title: first_result[:title],
+      snippet: first_result[:snippet],
+      context_link: first_result.dig(:image, :contextLink)
+    }
+  end
+end

--- a/app/serializers/recommendation_serializer.rb
+++ b/app/serializers/recommendation_serializer.rb
@@ -9,7 +9,10 @@ class RecommendationSerializer
           attributes: {
             name: recommendation[:name] || recommendation["name"],
             description: recommendation[:description] || recommendation["description"],
-            image: recommendation[:image] || recommendation["image"]
+            image: recommendation[:image] || recommendation["image"],
+            title: recommendation[:title],
+            snippet: recommendation[:snippet],
+            context_link: recommendation[:context_link]
           }
         }
       end

--- a/spec/gateways/google_search_gateway_spec.rb
+++ b/spec/gateways/google_search_gateway_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe GoogleSearchGateway do
+  let(:valid_plant_data) do
+    [
+      { name: "Tomato", description: "A plant that thrives in full sun." },
+      { name: "Zucchini", description: "Grows well in loamy soil." }
+    ]
+  end
+
+  let(:stubbed_response) do
+    {
+      kind: "customsearch#search",
+      items: [
+        {
+          link: "https://example.com/tomato.jpg",
+          title: "Tomato - Wikipedia",
+          snippet: "Tomato is a fruit from the nightshade family.",
+          image: {
+            contextLink: "https://en.wikipedia.org/wiki/Tomato"
+          }
+        }
+      ]
+    }.to_json
+  end
+
+  let(:empty_response) do
+    {
+      kind: "customsearch#search",
+      items: []
+    }.to_json
+  end
+
+  let(:gateway) { described_class.new }
+
+  describe "#enrich_with_google_data" do
+    it "enriches plant data with Google API results" do
+      stub_request(:get, /www.googleapis.com\/customsearch\/v1/)
+        .to_return(status: 200, body: stubbed_response, headers: { 'Content-Type' => 'application/json' })
+
+      enriched_data = gateway.enrich_with_google_data(valid_plant_data)
+
+      expect(enriched_data).to be_an Array
+      expect(enriched_data[0][:image]).to eq("https://example.com/tomato.jpg")
+      expect(enriched_data[0][:title]).to eq("Tomato - Wikipedia")
+      expect(enriched_data[0][:snippet]).to eq("Tomato is a fruit from the nightshade family.")
+      expect(enriched_data[0][:context_link]).to eq("https://en.wikipedia.org/wiki/Tomato")
+    end
+
+    it "skips plants with missing names" do
+      invalid_plant_data = [{ description: "Missing name field." }]
+
+      enriched_data = gateway.enrich_with_google_data(invalid_plant_data)
+
+      expect(enriched_data).to eq(invalid_plant_data)
+    end
+
+    it "returns the original plant data if Google API returns no results" do
+      stub_request(:get, /www.googleapis.com\/customsearch\/v1/)
+        .to_return(status: 200, body: empty_response, headers: { 'Content-Type' => 'application/json' })
+
+      enriched_data = gateway.enrich_with_google_data(valid_plant_data)
+
+      expect(enriched_data).to eq(valid_plant_data)
+    end
+
+    it "handles errors gracefully" do
+      stub_request(:get, /www.googleapis.com\/customsearch\/v1/)
+        .to_raise(StandardError.new("Network error"))
+
+      enriched_data = gateway.enrich_with_google_data(valid_plant_data)
+
+      expect(enriched_data).to eq(valid_plant_data)
+    end
+  end
+
+  describe "#fetch_google_data" do
+    it "returns data for a valid query" do
+      stub_request(:get, /www.googleapis.com\/customsearch\/v1/)
+        .to_return(status: 200, body: stubbed_response, headers: { 'Content-Type' => 'application/json' })
+
+      result = gateway.send(:fetch_google_data, "Tomato")
+
+      expect(result).to eq({
+        image: "https://example.com/tomato.jpg",
+        title: "Tomato - Wikipedia",
+        snippet: "Tomato is a fruit from the nightshade family.",
+        context_link: "https://en.wikipedia.org/wiki/Tomato"
+      })
+    end
+
+    it "returns nil for an empty response" do
+      stub_request(:get, /www.googleapis.com\/customsearch\/v1/)
+        .to_return(status: 200, body: empty_response, headers: { 'Content-Type' => 'application/json' })
+
+      result = gateway.send(:fetch_google_data, "Nonexistent Plant")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil for an API error" do
+      stub_request(:get, /www.googleapis.com\/customsearch\/v1/)
+        .to_return(status: 500)
+
+      result = gateway.send(:fetch_google_data, "Tomato")
+
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Added Google API functionality.

The response data from OpenAI is then sent to our custom Google search and returns working images.

Title, snippet, context link is extra data being brought in from the Google API incase we need the extra data for the FE. I can't really verify if we need it or not.

Serializer was altered for the additional info
Controller was altered for the addition of the Google API call.

google_search_gateway handles all of the logic
spec file created for new gateway test suite.

Once again lines 12-19 will need to be commented out on the BE to make real API calls.

Postman example of data being returned from both APIs. 
Even has the wikipedia link to that plant.

<img width="1264" alt="Screenshot 2025-01-15 at 8 23 47 PM" src="https://github.com/user-attachments/assets/8f172cb2-9a17-4409-b884-cef799cef175" />
